### PR TITLE
Use accelerometer crate's Accelerometer trait, I8x3, and F32x3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["mma7660", "embedded-hal-driver","grove", "accelerometer", "seeed"]
 
 
 [dependencies]
+accelerometer = "0.5"
 embedded-hal = "0.1.0"
 
 cast="0.2.2"


### PR DESCRIPTION
Impls the `accelerometer` crate's `Accelerometer` trait for reading accelerometer data, and imports the `I8x3` and `F32x3` types from it as well.

This allows for generic reuse of accelerometer data consuming crates which work across various accelerometer drivers.